### PR TITLE
Overrode FormatParameterName to set the parameter name directly

### DIFF
--- a/Tests/Tests.P3Net.Kraken.Data/Sql/SqlConnectionManagerTests.cs
+++ b/Tests/Tests.P3Net.Kraken.Data/Sql/SqlConnectionManagerTests.cs
@@ -1,11 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
+﻿/*
+ * Copyright © 2018 Federation of State Medical Boards
+ * All Rights Reserved
+ */
+using System;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using FluentAssertions;
 
-using P3Net.Kraken;
 using P3Net.Kraken.Data.Sql;
 using P3Net.Kraken.UnitTesting;
 
@@ -40,6 +42,44 @@ namespace Tests.P3Net.Kraken.Data.Sql
             Action a = () => new SqlConnectionManager("");
 
             a.Should().Throw<ArgumentException>();
+        }
+        #endregion
+
+        #region FormatParameterName
+
+        [TestMethod]
+        public void FormatParameterName_NotAlreadyFormatted ()
+        {
+            var name = "FirstName";
+            var expected = $"@{name}";
+
+            var target = new TestSqlConnectionManager();
+            var actual = target.GetParameterName(name);
+
+            actual.Should().Be(expected);
+        }
+
+        [TestMethod]
+        public void FormatParameterName_AlreadyFormatted ()
+        {
+            var name = "@FirstName";
+            var expected = name;
+
+            var target = new TestSqlConnectionManager();
+            var actual = target.GetParameterName(name);
+
+            actual.Should().Be(expected);
+        }
+        #endregion
+
+        #region Private Members
+
+        private sealed class TestSqlConnectionManager : SqlConnectionManager
+        {
+            public TestSqlConnectionManager() : base(@"Server=localhost;Database=Master")
+            { }
+
+            public string GetParameterName ( string originalName ) => FormatParameterName(originalName);
         }
         #endregion
     }

--- a/src/P3Net.Kraken.Data/Sql/SqlConnectionManager.cs
+++ b/src/P3Net.Kraken.Data/Sql/SqlConnectionManager.cs
@@ -26,6 +26,11 @@ namespace P3Net.Kraken.Data.Sql
         }
         #endregion
 
+        /// <summary>Formats the parameter name.</summary>
+        /// <param name="originalName">The parameter name.</param>
+        /// <returns>The formatted parameter name.</returns>
+        protected override string FormatParameterName ( string originalName ) => originalName.EnsureStartsWith("@");
+
         /// <summary>Gets the schema information from the database.</summary>
         /// <returns>The schema information.</returns>
         protected override SchemaInformation LoadSchema ()


### PR DESCRIPTION
Overrode FormatParameterName to set the parameter name directly instead of calling LoadSchema.

Added unit tests. #16